### PR TITLE
Add margin allocation engine and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+__pycache__/
+tests/__pycache__/

--- a/allocation_engine.py
+++ b/allocation_engine.py
@@ -1,88 +1,82 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a//dev/null b/allocation_engine.py
-index 0000000000000000000000000000000000000000..78f9ca31000d27478699fd6253b69bb8f58871d5 100644
---- a//dev/null
-+++ b/allocation_engine.py
-@@ -0,0 +1,79 @@
-+"""Simple allocation engine based on margin requirements and safe capacity."""
-+from __future__ import annotations
-+
-+from dataclasses import dataclass
-+from typing import List, Dict, Tuple
-+import csv
-+
-+
-+@dataclass
-+class Position:
-+    ticker: str
-+    name: str
-+    value: float
-+    m: float  # maintenance requirement
-+    req_amt: float
-+    safe_loan: float  # safe capacity under 50% stress
-+
-+
-+def allocate_margin(positions: List[Position], margin_amount: float) -> Tuple[Dict[str, float], float]:
-+    """Allocate ``margin_amount`` across ``positions`` based on safe capacity.
-+
-+    Returns a tuple of (allocations, leftover) where ``allocations`` is a
-+    mapping from ticker to allocated amount (capped at ``safe_loan``) and
-+    ``leftover`` is any margin that could not be deployed because all
-+    positions hit their safe capacity.
-+    """
-+    total_safe = sum(p.safe_loan for p in positions)
-+    if total_safe <= 0:
-+        return {p.ticker: 0.0 for p in positions}, margin_amount
-+
-+    allocations: Dict[str, float] = {}
-+    for p in positions:
-+        weight = p.safe_loan / total_safe
-+        allocation = margin_amount * weight
-+        allocations[p.ticker] = min(allocation, p.safe_loan)
-+
-+    leftover = margin_amount - sum(allocations.values())
-+    if leftover < 0:  # avoid tiny negative due to float rounding
-+        leftover = 0.0
-+    return allocations, leftover
-+
-+
-+def load_positions(path: str) -> List[Position]:
-+    positions: List[Position] = []
-+    with open(path, newline="") as f:
-+        reader = csv.DictReader(f)
-+        for row in reader:
-+            positions.append(
-+                Position(
-+                    ticker=row["Ticker"],
-+                    name=row["Name"],
-+                    value=float(row["Value"]),
-+                    m=float(row["M"]),
-+                    req_amt=float(row["ReqAmt"]),
-+                    safe_loan=float(row["SafeLoan_per_position"]),
-+                )
-+            )
-+    return positions
-+
-+
-+if __name__ == "__main__":
-+    import argparse
-+
-+    parser = argparse.ArgumentParser(description="Allocate margin across positions.")
-+    parser.add_argument("margin", type=float, help="Total margin to deploy")
-+    parser.add_argument(
-+        "--positions",
-+        default="data/positions.csv",
-+        help="CSV file containing position data",
-+    )
-+    args = parser.parse_args()
-+
-+    positions = load_positions(args.positions)
-+    allocations, leftover = allocate_margin(positions, args.margin)
-+    print(f"Total allocated: {sum(allocations.values()):.2f}")
-+    if leftover:
-+        print(f"Leftover margin: {leftover:.2f}")
-+    for p in positions:
-+        print(f"{p.ticker}: {allocations[p.ticker]:.2f} (cap {p.safe_loan:.2f})")
- 
-EOF
-)
+"""Simple allocation engine based on margin requirements and safe capacity."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+import csv
+
+
+@dataclass
+class Position:
+    ticker: str
+    name: str
+    value: float
+    m: float  # maintenance requirement
+    req_amt: float
+    safe_loan: float  # safe capacity under 50% stress
+
+
+def allocate_margin(positions: List[Position], margin_amount: float) -> Tuple[Dict[str, float], float]:
+    """Allocate ``margin_amount`` across ``positions`` based on safe capacity.
+
+    Returns a tuple of (allocations, leftover) where ``allocations`` is a
+    mapping from ticker to allocated amount (capped at ``safe_loan``) and
+    ``leftover`` is any margin that could not be deployed because all
+    positions hit their safe capacity.
+    """
+
+    total_safe = sum(p.safe_loan for p in positions)
+    if total_safe <= 0:
+        return {p.ticker: 0.0 for p in positions}, margin_amount
+
+    allocations: Dict[str, float] = {}
+    for p in positions:
+        weight = p.safe_loan / total_safe
+        allocation = margin_amount * weight
+        allocations[p.ticker] = min(allocation, p.safe_loan)
+
+    leftover = margin_amount - sum(allocations.values())
+    if leftover < 0:  # avoid tiny negative due to float rounding
+        leftover = 0.0
+    return allocations, leftover
+
+
+def load_positions(path: str) -> List[Position]:
+    positions: List[Position] = []
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            positions.append(
+                Position(
+                    ticker=row["Ticker"],
+                    name=row["Name"],
+                    value=float(row["Value"]),
+                    m=float(row["M"]),
+                    req_amt=float(row["ReqAmt"]),
+                    safe_loan=float(row["SafeLoan_per_position"]),
+                )
+            )
+    return positions
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Allocate margin across positions.")
+    parser.add_argument("margin", type=float, help="Total margin to deploy")
+    parser.add_argument(
+        "--positions",
+        default="data/positions.csv",
+        help="CSV file containing position data",
+    )
+    args = parser.parse_args()
+
+    positions = load_positions(args.positions)
+    allocations, leftover = allocate_margin(positions, args.margin)
+    print(f"Total allocated: {sum(allocations.values()):.2f}")
+    if leftover:
+        print(f"Leftover margin: {leftover:.2f}")
+    for p in positions:
+        print(f"{p.ticker}: {allocations[p.ticker]:.2f} (cap {p.safe_loan:.2f})")
+

--- a/data/positions.csv
+++ b/data/positions.csv
@@ -1,33 +1,24 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a//dev/null b/data/positions.csv
-index 0000000000000000000000000000000000000000..fe6ffffbd4ef301a53f0d5b954c12add5bf5bc43 100644
---- a//dev/null
-+++ b/data/positions.csv
-@@ -0,0 +1,24 @@
-+Ticker,Name,Value,M,ReqAmt,SafeLoan_per_position
-+WMT,Walmart Inc,52.49,0.3,15.747,28.26384615
-+EWS,iShares MSCI Singapore ETF,50.17,0.25,12.5425,30.102
-+JMIA,Jumia Technologies,705.19,0.6,423.114,176.2975
-+BTBT,Bit Digital,270.48,1,270.48,0
-+HESM,Hess Midstream LP,418.78,0.3,125.634,225.4969231
-+PFE,Pfizer Inc,350.32,0.3,105.096,188.6338462
-+CAT,Caterpillar Inc,331.16,0.3,99.348,178.3169231
-+SHOC,Strive U.S. Semiconductor ETF,94.1,1,94.1,0
-+EXC,Exelon Corp,276.02,0.3,82.806,148.6261538
-+TU,Telus Corp,224.17,0.3,67.251,120.7069231
-+QSR,Restaurant Brands Intl,221.37,0.3,66.411,119.1992308
-+BCDF,Horizon Kinetics Fund,63.06,1,63.06,0
-+PSX,Phillips 66,181.44,0.3,54.432,97.69846154
-+FSM,Fortuna Mining,127.62,0.42,53.6004,52.12647887
-+POAI,Predictive Oncology,53.1,1,53.1,0
-+RITM,Rithm Capital,176.48,0.3,52.944,95.02769231
-+BLMN,Bloomin' Brands,86.16,0.6,51.696,21.54
-+CVS,CVS Health,165.33,0.3,49.599,89.02384615
-+XOM,Exxon Mobil,128.79,0.3,38.637,69.34846154
-+DSU,BlackRock Debt Strategies,52.5,0.54,28.35,15.68181818
-+BIT,BlackRock Multi-Sector Income,55.6,0.36,20.016,26.16470588
-+WASH,Washington Trust Bancorp,49.27,0.35,17.2445,23.72259259
-+CNQ,Canadian Natural Resources,55.84,0.3,16.752,30.06769231
- 
-EOF
-)
+Ticker,Name,Value,M,ReqAmt,SafeLoan_per_position
+WMT,Walmart Inc,52.49,0.3,15.747,28.26384615
+EWS,iShares MSCI Singapore ETF,50.17,0.25,12.5425,30.102
+JMIA,Jumia Technologies,705.19,0.6,423.114,176.2975
+BTBT,Bit Digital,270.48,1,270.48,0
+HESM,Hess Midstream LP,418.78,0.3,125.634,225.4969231
+PFE,Pfizer Inc,350.32,0.3,105.096,188.6338462
+CAT,Caterpillar Inc,331.16,0.3,99.348,178.3169231
+SHOC,Strive U.S. Semiconductor ETF,94.1,1,94.1,0
+EXC,Exelon Corp,276.02,0.3,82.806,148.6261538
+TU,Telus Corp,224.17,0.3,67.251,120.7069231
+QSR,Restaurant Brands Intl,221.37,0.3,66.411,119.1992308
+BCDF,Horizon Kinetics Fund,63.06,1,63.06,0
+PSX,Phillips 66,181.44,0.3,54.432,97.69846154
+FSM,Fortuna Mining,127.62,0.42,53.6004,52.12647887
+POAI,Predictive Oncology,53.1,1,53.1,0
+RITM,Rithm Capital,176.48,0.3,52.944,95.02769231
+BLMN,Bloomin' Brands,86.16,0.6,51.696,21.54
+CVS,CVS Health,165.33,0.3,49.599,89.02384615
+XOM,Exxon Mobil,128.79,0.3,38.637,69.34846154
+DSU,BlackRock Debt Strategies,52.5,0.54,28.35,15.68181818
+BIT,BlackRock Multi-Sector Income,55.6,0.36,20.016,26.16470588
+WASH,Washington Trust Bancorp,49.27,0.35,17.2445,23.72259259
+CNQ,Canadian Natural Resources,55.84,0.3,16.752,30.06769231

--- a/tests/test_allocation.py
+++ b/tests/test_allocation.py
@@ -1,26 +1,25 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a//dev/null b/tests/test_allocation.py
-index 0000000000000000000000000000000000000000..d3fe0ba0066f96a3e5685ce7e0ebeb802ed45903 100644
---- a//dev/null
-+++ b/tests/test_allocation.py
-@@ -0,0 +1,17 @@
-+from allocation_engine import Position, allocate_margin
-+
-+def test_allocation_proportional():
-+    positions = [
-+        Position("A", "", 100, 0.3, 30, 50),
-+        Position("B", "", 200, 0.3, 60, 150),
-+    ]
-+    allocations, leftover = allocate_margin(positions, 100)
-+    assert leftover == 0
-+    assert round(allocations["A"], 2) == 25.00
-+    assert round(allocations["B"], 2) == 75.00
-+
-+def test_allocation_caps_and_leftover():
-+    positions = [Position("A", "", 100, 0.3, 30, 50)]
-+    allocations, leftover = allocate_margin(positions, 80)
-+    assert round(allocations["A"], 2) == 50.00
-+    assert round(leftover, 2) == 30.00
- 
-EOF
-)
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from allocation_engine import Position, allocate_margin
+
+
+def test_allocation_proportional():
+    positions = [
+        Position("A", "", 100, 0.3, 30, 50),
+        Position("B", "", 200, 0.3, 60, 150),
+    ]
+    allocations, leftover = allocate_margin(positions, 100)
+    assert leftover == 0
+    assert round(allocations["A"], 2) == 25.00
+    assert round(allocations["B"], 2) == 75.00
+
+
+def test_allocation_caps_and_leftover():
+    positions = [Position("A", "", 100, 0.3, 30, 50)]
+    allocations, leftover = allocate_margin(positions, 80)
+    assert round(allocations["A"], 2) == 50.00
+    assert round(leftover, 2) == 30.00
+


### PR DESCRIPTION
## Summary
- Implement a simple margin allocator that distributes capital by each position's safe-capacity weight and reports leftover margin.
- Load position data from CSV and offer a CLI to run allocations from the command line.
- Add unit tests covering proportional allocation and leftover handling.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a69053ddb88322807127c598f87fc3