### PR TITLE
ci: set workflow working directories

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -19,9 +19,11 @@ jobs:
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
+      working-directory: Thimie
       run: |
         conda env update --file environment.yml --name base
     - name: Lint with flake8
+      working-directory: Thimie
       run: |
         conda install flake8
         # stop the build if there are Python syntax errors or undefined names
@@ -29,6 +31,7 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
+      working-directory: Thimie
       run: |
         conda install pytest
         pytest

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,12 +27,14 @@ jobs:
           python-version: "3.x"
 
       - name: Build release distributions
+        working-directory: Thimie
         run: |
           # NOTE: put your own distribution build steps here.
           python -m pip install build
           python -m build
 
       - name: Upload distributions
+        working-directory: Thimie
         uses: actions/upload-artifact@v4
         with:
           name: release-dists
@@ -59,12 +61,14 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
+        working-directory: Thimie
         uses: actions/download-artifact@v4
         with:
           name: release-dists
           path: dist/
 
       - name: Publish release distributions to PyPI
+        working-directory: Thimie
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/


### PR DESCRIPTION
## Summary
- ensure CI steps run within project directory
- scope release workflow steps to project folder

## Testing
- `python -m build` *(fails: Source /workspace/Thimie does not appear to be a Python project: no pyproject.toml or setup.py)*
- `pytest` *(fails: IndentationError in tests/test_allocation.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a693d1ea5883229bf9012ce8163dce